### PR TITLE
Move to Options objects for some ids

### DIFF
--- a/src/DiscordDotNet.CommandLine/Commands/ApplicationsCommandsGetCommand.cs
+++ b/src/DiscordDotNet.CommandLine/Commands/ApplicationsCommandsGetCommand.cs
@@ -1,5 +1,6 @@
 ﻿using DiscordDotNet.Abstractions;
 using DiscordDotNet.Abstractions.DataModel;
+using DiscordDotNet.CommandLine.Options;
 using DiscordDotNet.CommandLine.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -17,21 +18,21 @@ namespace DiscordDotNet.CommandLine.Commands
         {
             var commandIdOpt = new Option<string>("--command-id", "The command id to request (omit for all)", ArgumentArity.ZeroOrOne);
             AddOption(commandIdOpt);
-            Handler = CommandHandler.Create<InvocationContext, IHost, string, string>(Exec);
+            Handler = CommandHandler.Create<InvocationContext, IHost, ApplicationOptions, string>(Exec);
         }
 
-        private async Task<int> Exec(InvocationContext invocationContext, IHost host, string applicationId, string commandId = null)
+        private async Task<int> Exec(InvocationContext invocationContext, IHost host, ApplicationOptions appIdOptions, string commandId = null)
         {
             var client = host.Services.GetRequiredService<IDiscordWebClient>();
             if (commandId is string commId)
             {
-                var appCommands = await client.GetApplicationCommand(applicationId, commId).ConfigureAwait(false);
+                var appCommands = await client.GetApplicationCommand(appIdOptions.ApplicationId, commId).ConfigureAwait(false);
 
                 invocationContext.Console.Append(new JsonView<ApplicationCommand>(appCommands));
             }
             else
             {
-                var commands = await client.GetApplicationCommands(applicationId).ConfigureAwait(false);
+                var commands = await client.GetApplicationCommands(appIdOptions.ApplicationId).ConfigureAwait(false);
 
                 var tableView = new ApplicationCommandTableView(commands);
 

--- a/src/DiscordDotNet.CommandLine/Commands/ApplicationsGuildsCommandsGetCommand.cs
+++ b/src/DiscordDotNet.CommandLine/Commands/ApplicationsGuildsCommandsGetCommand.cs
@@ -1,5 +1,6 @@
 ﻿using DiscordDotNet.Abstractions;
 using DiscordDotNet.Abstractions.DataModel;
+using DiscordDotNet.CommandLine.Options;
 using DiscordDotNet.CommandLine.Views;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -17,21 +18,21 @@ namespace DiscordDotNet.CommandLine.Commands
         {
             var commandIdOpt = new Option<string>("--command-id", "The command id to request (omit for all)", ArgumentArity.ZeroOrOne);
             AddOption(commandIdOpt);
-            Handler = CommandHandler.Create<InvocationContext, IHost, string, string, string>(Exec);
+            Handler = CommandHandler.Create<InvocationContext, IHost, ApplicationOptions, GuildOptions, string>(Exec);
         }
-        private async Task<int> Exec(InvocationContext invocationContext, IHost host, string applicationId, string guildId, string commandId = null)
+        private async Task<int> Exec(InvocationContext invocationContext, IHost host, ApplicationOptions appOptions, GuildOptions guildOptions, string commandId = null)
         {
             var client = host.Services.GetRequiredService<IDiscordWebClient>();
 
             if (commandId is string commId)
             {
-                var commands = await client.GetGuildApplicationCommand(applicationId, guildId, commId).ConfigureAwait(false);
+                var commands = await client.GetGuildApplicationCommand(appOptions.ApplicationId, guildOptions.GuildId, commId).ConfigureAwait(false);
 
                 invocationContext.Console.Append(new JsonView<ApplicationCommand>(commands));
             }
             else
             {
-                var commands = await client.GetGuildApplicationCommands(applicationId, guildId).ConfigureAwait(false);
+                var commands = await client.GetGuildApplicationCommands(appOptions.ApplicationId, guildOptions.GuildId).ConfigureAwait(false);
 
                 var tableView = new ApplicationCommandTableView(commands);
 

--- a/src/DiscordDotNet.CommandLine/Options/ApplicationOptions.cs
+++ b/src/DiscordDotNet.CommandLine/Options/ApplicationOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace DiscordDotNet.CommandLine.Options
+{
+    internal class ApplicationOptions
+    {
+        public ApplicationOptions(string applicationId)
+        {
+            ApplicationId = applicationId;
+        }
+
+        public string ApplicationId { get; }
+    }
+}

--- a/src/DiscordDotNet.CommandLine/Options/GuildApplicationOptions.cs
+++ b/src/DiscordDotNet.CommandLine/Options/GuildApplicationOptions.cs
@@ -1,0 +1,12 @@
+﻿namespace DiscordDotNet.CommandLine.Options
+{
+    internal class GuildOptions
+    {
+        public GuildOptions(string guildId)
+        {
+            GuildId = guildId;
+        }
+
+        public string GuildId { get; }
+    }
+}


### PR DESCRIPTION
It makes sense to deal with objects where possible instead of strings to allow the type system to work with the developer.